### PR TITLE
Drop empty backend packages

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -2,6 +2,10 @@ qutebrowser (3.2.1-1) unstable; urgency=medium
 
   * New upstream version 3.2.1
 
+  [ Bastian Germann ]
+  * Drop qutebrowser-qtwebkit (Closes: #1093553)
+  * Drop qutebrowser-qtwebengine (Closes: #892562)
+
  -- Fritz Reichwald <reichwald@b1-systems.de>  Wed, 24 Jul 2024 11:32:46 +0200
 
 qutebrowser (3.1.0-1) unstable; urgency=medium

--- a/debian/control
+++ b/debian/control
@@ -24,7 +24,7 @@ Architecture: all
 Depends: python3 (>= 3.8),
          python3-importlib-resources | python3 (>= 3.9),
          python3-yaml,
-         qutebrowser-qtwebengine | qutebrowser-qtwebkit,
+         qutebrowser-qtwebengine,
          ${misc:Depends},
          ${python3:Depends}
 Suggests: libjs-pdf,
@@ -35,8 +35,7 @@ Description: Keyboard-driven, vim-like browser based on Python and Qt
  based on Python and Qt and was inspired by other browsers/addons
  like dwb and Vimperator/Pentadactyl.
  .
- qutebrowser supports two different rendering engine backends:
- QtWebKit and QtWebEngine.
+ qutebrowser supports the rendering engine QtWebEngine.
 
 Package: qutebrowser-qtwebengine
 Architecture: all
@@ -57,26 +56,3 @@ Description: QtWebEngine backend dependency package for qutebrowser
  .
  This package contains all the required dependencies to use
  qutebrowser with the QtWebEngine backend.
-
-Package: qutebrowser-qtwebkit
-Architecture: all
-Depends: libqt5core5t64 (>= 5.15.0),
-         libqt5dbus5t64 (>= 5.15.0),
-         libqt5sql5-sqlite,
-         libqt5webkit5 (>= 5.212),
-         python3-pyqt5,
-         python3-pyqt5.qtopengl,
-         python3-pyqt5.qtquick,
-         python3-pyqt5.qtsql,
-         python3-pyqt5.qtwebkit (>= 5.15.0),
-         qutebrowser (= ${source:Version}),
-         ${misc:Depends}
-Recommends: ca-certificates,
-            python3-pygments
-Description: QtWebKit backend dependency package for qutebrowser
- qutebrowser is a keyboard-focused browser with a minimal GUI. It's
- based on Python and PyQt5 and was inspired by other browsers/addons
- like dwb and Vimperator/Pentadactyl.
- .
- This package contains all the required dependencies to use
- qutebrowser with the QtWebKit backend.

--- a/debian/control
+++ b/debian/control
@@ -24,10 +24,14 @@ Architecture: all
 Depends: python3 (>= 3.8),
          python3-importlib-resources | python3 (>= 3.9),
          python3-yaml,
-         qutebrowser-qtwebengine,
+         python3-pyqt6,
+         python3-pyqt6.qtquick,
+         python3-pyqt6.qtwebengine (>= 6.2.0),
+         libqt6sql6-sqlite,
          ${misc:Depends},
          ${python3:Depends}
 Suggests: libjs-pdf,
+          python3-pygments,
           nodejs
 Provides: www-browser
 Description: Keyboard-driven, vim-like browser based on Python and Qt
@@ -36,23 +40,3 @@ Description: Keyboard-driven, vim-like browser based on Python and Qt
  like dwb and Vimperator/Pentadactyl.
  .
  qutebrowser supports the rendering engine QtWebEngine.
-
-Package: qutebrowser-qtwebengine
-Architecture: all
-Depends: libqt6core6 (>= 6.2.0),
-         libqt6dbus6 (>= 6.2.0),
-         libqt6sql6-sqlite,
-         libqt6webenginecore6 (>= 6.2.0),
-         python3-pyqt6,
-         python3-pyqt6.qtquick,
-         python3-pyqt6.qtwebengine (>= 6.2.0),
-         qutebrowser (= ${source:Version}),
-         ${misc:Depends}
-Suggests: python3-pygments
-Description: QtWebEngine backend dependency package for qutebrowser
- qutebrowser is a keyboard-focused browser with a minimal GUI. It's
- based on Python and PyQt5 and was inspired by other browsers/addons
- like dwb and Vimperator/Pentadactyl.
- .
- This package contains all the required dependencies to use
- qutebrowser with the QtWebEngine backend.


### PR DESCRIPTION
QtWebKit is discouraged from being installed because of known security vulnerabilites.
I am in the process of removing it from Debian.